### PR TITLE
Fix task collection failure when collecting tcmalloc metrics

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -51,7 +51,7 @@ func GetConnection(URL, AuthPassword, AuthUserName string) (*mgo.Session, error)
 // GetServerStatus returns server status
 func GetServerStatus(session *mgo.Session) (ServerStatus, error) {
 	result := ServerStatus{}
-	if err := session.Run(bson.D{{"serverStatus", 1}}, &result); err != nil {
+	if err := session.Run(bson.D{{"serverStatus", 1}, {"tcmalloc", 1}}, &result); err != nil {
 		return result, err
 	}
 	defer session.Close()

--- a/mongodbcollector/metrics.go
+++ b/mongodbcollector/metrics.go
@@ -152,30 +152,33 @@ func getTmallocMetrics(status mwrapper.ServerStatus, mts []plugin.Metric, meta m
 		ns := make([]plugin.NamespaceElement, len(mt.Namespace))
 		copy(ns, mt.Namespace)
 
-		switch ns[nsSubMetric].Value {
-		case "current_allocated_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Generic.CurrentAllocatedBytes, ns, meta))
-		case "heap_size":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Generic.HeapSize, ns, meta))
-		case "pageheap_free_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.PageheapFreeBytes, ns, meta))
-		case "pageheap_unmapped_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.PageheapUnmappedBytes, ns, meta))
-		case "max_total_thread_cache_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.MaxTotalThreadCacheBytes, ns, meta))
-		case "current_total_thread_cache_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.CurrentTotalThreadCacheBytes, ns, meta))
-		case "total_free_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.TotalFreeBytes, ns, meta))
-		case "central_cache_free_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.CentralCacheFreeBytes, ns, meta))
-		case "transfer_cache_free_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.TransferCacheFreeBytes, ns, meta))
-		case "thread_cache_free_bytes":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.ThreadCacheFreeBytes, ns, meta))
-		case "aggressive_memory_decommit":
-			metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.AggressiveMemoryDecommit, ns, meta))
-
+		if status.Tcmalloc == nil { // Skip metric collection when tcmalloc is not available in installed MongoDB version
+			metrics = append(metrics, createMeasurement(mt, nil, ns, meta))
+		} else {
+			switch ns[nsSubMetric].Value {
+			case "current_allocated_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Generic.CurrentAllocatedBytes, ns, meta))
+			case "heap_size":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Generic.HeapSize, ns, meta))
+			case "pageheap_free_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.PageheapFreeBytes, ns, meta))
+			case "pageheap_unmapped_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.PageheapUnmappedBytes, ns, meta))
+			case "max_total_thread_cache_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.MaxTotalThreadCacheBytes, ns, meta))
+			case "current_total_thread_cache_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.CurrentTotalThreadCacheBytes, ns, meta))
+			case "total_free_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.TotalFreeBytes, ns, meta))
+			case "central_cache_free_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.CentralCacheFreeBytes, ns, meta))
+			case "transfer_cache_free_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.TransferCacheFreeBytes, ns, meta))
+			case "thread_cache_free_bytes":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.ThreadCacheFreeBytes, ns, meta))
+			case "aggressive_memory_decommit":
+				metrics = append(metrics, createMeasurement(mt, status.Tcmalloc.Tcmalloc.AggressiveMemoryDecommit, ns, meta))
+			}
 		}
 	}
 	return metrics


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #7 

Summary of changes:
- Added tcmalloc parameter to session.Run call
- Checking if Tcmalloc is available (not nil) - if not, do not try to return Tcmalloc data (it makes plugin fails)

How to verify it:
- Load plugin
- Create task, which uses /intel/mongodb/tmalloc metrics
- Let the task collect data - it won't fail anymore, even if tcmalloc metric is not available in installed MongoDB version

Testing done:
- Manual testing

